### PR TITLE
pc - add form on home page and link to script output

### DIFF
--- a/frontend/src/main/pages/HomePage.jsx
+++ b/frontend/src/main/pages/HomePage.jsx
@@ -1,7 +1,16 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import DokkuScript from "main/components/DokkuScripts/DokkuScript";
+import DokkuScriptForm from "main/components/DokkuScripts/DokkuScriptForm";
+
+import { useState } from "react";
 
 export default function HomePage() {
+  const [params, setParams] = useState();
+
+  const callback = (params) => {
+    setParams(params);
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -11,9 +20,13 @@ export default function HomePage() {
           at UC Santa Barbara.
         </p>
       </div>
+      <div>
+        <h2>Specify Dokku App</h2>
+        <DokkuScriptForm callback={callback} />
+      </div>
       <div className="pt-2">
         <h2>Generated Dokku Script</h2>
-        <DokkuScript />
+        <DokkuScript {...params} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/HomePage.test.jsx
+++ b/frontend/src/tests/pages/HomePage.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import HomePage from "main/pages/HomePage";
 import { MemoryRouter } from "react-router";
 import { expect } from "vitest";
+import userEvent from "@testing-library/user-event";
 
 describe("HomePage tests", () => {
   test("renders without crashing", async () => {
@@ -12,5 +13,19 @@ describe("HomePage tests", () => {
     );
     await screen.findByText(/Dokku Config/);
     expect(screen.getByText(/Dokku Config/)).toBeInTheDocument();
+  });
+
+  test("passed values from form to script", async () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    const testId = "DokkuScriptForm";
+    const appnameInput = screen.getByTestId(`${testId}-appname`);
+    await userEvent.type(appnameInput, "team01");
+    await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+    const preElement = await screen.findByTestId("dokkuscript");
+    expect(preElement).toHaveTextContent("dokku apps:create team01");
   });
 });


### PR DESCRIPTION
In this PR, we add the form to the home page and link it to the script to create the result.

From this point forward, completing the app is merely a matter of adding more elements to the form, and ensuring that each one is correctly reflected in the script.


![dokku-config](https://github.com/user-attachments/assets/a29bcc4d-6fd6-48ca-ad70-99d394661ad6)
