### PR TITLE
pc - adjust workflow 53 to match workflow 55

### DIFF
--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -45,6 +45,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
           forceRebuild: true
+          configFile: 'chromatic.config.json'  
       - name: Echo output
         run: |
           echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"


### PR DESCRIPTION
In this PR, we update workflow 53 to use the config file from workflow 55.

This pulls in the configuration for turbosnap and a11y for chromatic.