### PR TITLE
pc - fix footer per issue 7 to explain app and link to source code

### DIFF
--- a/frontend/src/main/components/Nav/Footer.jsx
+++ b/frontend/src/main/components/Nav/Footer.jsx
@@ -4,7 +4,24 @@ export default function Footer() {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5" data-testid="Footer">
       <Container>
-        <p>This is a sample frontend only webapp.</p>
+        <p>
+          The purpose of this webapp is to assist students and course staff in
+          CMPSC156 with configuring dokku deployments for full stack web apps
+          for CMPSC 156, a course in Software Engineering at UC Santa Barbara.
+        </p>
+        <p>
+          This webapp is open source; the source code is available on{" "}
+          <a href="https://github.com/ucsb-cs156/dokku-config">GitHub</a>.
+        </p>
+        <p>
+          This also serves as an example of a webapp that is "frontend only" (no
+          backend) built using React with the CMPSC 156 toolchain and deployed
+          on Github Pages.
+        </p>
+        <p>
+          Copyright &copy; 2026 by the Regents of the University of California,
+          All rights reserved.
+        </p>
       </Container>
     </footer>
   );

--- a/frontend/src/tests/components/Nav/Footer.test.jsx
+++ b/frontend/src/tests/components/Nav/Footer.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Footer from "main/components/Nav/Footer";
 import { afterEach, expect, beforeEach, vi, describe, test } from "vitest";
 
@@ -6,7 +6,14 @@ import { afterEach, expect, beforeEach, vi, describe, test } from "vitest";
 // The vi.doMock and vi.resetModules calls should be inside the describe blocks.
 
 describe("Footer tests", () => {
-  describe("SystemInfo returns content", () => {
+  const expectedText = [
+    `The purpose of this webapp is to assist students and course staff in CMPSC156 with configuring dokku deployments for full stack web apps for CMPSC 156, a course in Software Engineering at UC Santa Barbara.`,
+    `This webapp is open source; the source code is available on GitHub.`,
+    `This also serves as an example of a webapp that is "frontend only" (no backend) built using React with the CMPSC 156 toolchain and deployed on Github Pages.`,
+    `Copyright © 2026 by the Regents of the University of California, All rights reserved.`,
+  ];
+
+  describe("<Footer />", () => {
     beforeEach(() => {
       // Clears the module cache to ensure each test suite starts fresh.
       vi.resetModules();
@@ -16,16 +23,23 @@ describe("Footer tests", () => {
       vi.clearAllMocks();
     });
 
-    test("renders correctly with system info content", async () => {
+    test("renders text correctly", async () => {
       render(<Footer />);
-      // Wait for the query to resolve and content to appear.
-      await waitFor(() => {
-        expect(screen.getByText(/This is a sample/)).toBeInTheDocument();
+
+      await screen.findByTestId("Footer");
+
+      const actual = screen
+        .getByTestId("Footer")
+        .textContent.replace(/\s+/g, " ")
+        .trim();
+
+      const expectedNormalized = expectedText.map((s) =>
+        s.replace(/\s+/g, " ").trim(),
+      );
+
+      expectedNormalized.forEach((s) => {
+        expect(actual).toContain(s);
       });
-
-      const expectedText = "This is a sample frontend only webapp.";
-
-      expect(screen.getByTestId("Footer").textContent).toBe(expectedText);
     });
   });
 });


### PR DESCRIPTION
Closes #7 

In this issue we replace the footer:

<img width="421" height="92" alt="image" src="https://github.com/user-attachments/assets/6ceada21-604a-4907-83e1-eb238051d35a" />


With:

<img width="1362" height="182" alt="image" src="https://github.com/user-attachments/assets/382c660e-54a2-492b-8f97-85aa18c2e906" />


