### PR TITLE
pc - cache the inputs to the form in local storage

### DIFF
--- a/frontend/src/main/components/DokkuScripts/DokkuScriptForm.jsx
+++ b/frontend/src/main/components/DokkuScripts/DokkuScriptForm.jsx
@@ -6,12 +6,13 @@ const defaultCallback = (result) => {
   window.alert(`Form submitted: ${JSON.stringify(result)}`);
 };
 
-function DokkuScriptForm({ callback = defaultCallback }) {
+function DokkuScriptForm({ callback = defaultCallback, params = {} }) {
   const {
     handleSubmit,
     register,
     formState: { errors },
   } = useForm();
+
   const testId = "DokkuScriptForm";
   return (
     <Container className="py-5 DokkuScriptForm" data-testid={testId}>
@@ -33,6 +34,7 @@ function DokkuScriptForm({ callback = defaultCallback }) {
                     data-testid={`${testId}-appname`}
                     type="text"
                     isInvalid={Boolean(errors.appname)}
+                    defaultValue={params.appname || ""}
                     {...register("appname", {
                       required: "appname is required.",
                     })}

--- a/frontend/src/main/pages/HomePage.jsx
+++ b/frontend/src/main/pages/HomePage.jsx
@@ -7,9 +7,16 @@ import { useState } from "react";
 export default function HomePage() {
   const [params, setParams] = useState();
 
+  const testId = "HomePage";
+
   const callback = (params) => {
     setParams(params);
+    localStorage.setItem(`${testId}.params`, JSON.stringify(params));
   };
+
+  localStorage.getItem(`${testId}.params`) &&
+    !params &&
+    setParams(JSON.parse(localStorage.getItem(`${testId}.params`)));
 
   return (
     <BasicLayout>
@@ -22,7 +29,7 @@ export default function HomePage() {
       </div>
       <div>
         <h2>Specify Dokku App</h2>
-        <DokkuScriptForm callback={callback} />
+        <DokkuScriptForm callback={callback} params={params} />
       </div>
       <div className="pt-2">
         <h2>Generated Dokku Script</h2>

--- a/frontend/src/tests/pages/HomePage.test.jsx
+++ b/frontend/src/tests/pages/HomePage.test.jsx
@@ -28,4 +28,38 @@ describe("HomePage tests", () => {
     const preElement = await screen.findByTestId("dokkuscript");
     expect(preElement).toHaveTextContent("dokku apps:create team01");
   });
+
+  test("uses values from local storage when set", async () => {
+    // Mock localStorage
+    const mockSetItem = vi.fn();
+    const mockGetItem = vi.fn((key) => {
+      if (key === "HomePage.params") {
+        return JSON.stringify({ appname: "foobar" });
+      }
+      return null;
+    });
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        setItem: mockSetItem,
+        getItem: mockGetItem,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    const testId = "DokkuScriptForm";
+    const appnameInput = screen.getByTestId(`${testId}-appname`);
+    expect(appnameInput).toHaveValue("foobar");
+
+    await userEvent.clear(appnameInput);
+    await userEvent.type(appnameInput, "barfoo");
+    await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+    expect(mockSetItem).toHaveBeenCalledWith(
+      "HomePage.params",
+      JSON.stringify({ appname: "barfoo" }),
+    );
+  });
 });


### PR DESCRIPTION
Closes #9 

With this PR, we add caching of the params in local storage so that when using the same browser, the params will be retained from one usage to the next.

This is convenient because teams tend to work on the same app for a while with only minor changes.

But, we should include a "clear" function for sensitive elements such as client id and client secret in a future PR.