### PR TITLE
pc - update dokku script for a more efficient fast deployment

### DIFF
--- a/frontend/src/main/components/DokkuScripts/DokkuScriptGenerate.jsx
+++ b/frontend/src/main/components/DokkuScripts/DokkuScriptGenerate.jsx
@@ -13,14 +13,15 @@ function DokkuScript({
       dokku git:set ${appname} keep-git-dir true
       dokku config:set --no-restart ${appname} PRODUCTION=true
       dokku config:set --no-restart ${appname} SOURCE_REPO=https://github.com/${org}/${repo}
+      dokku config:set ${appname} --no-restart GOOGLE_CLIENT_ID=${google_client_id}
+      dokku config:set ${appname} --no-restart GOOGLE_CLIENT_SECRET=${google_client_secret}
       dokku postgres:create ${appname}-db
       dokku postgres:link ${appname}-db ${appname}
       dokku git:sync ${appname} https://github.com/${org}/${repo} main
       dokku ps:rebuild ${appname}
       dokku letsencrypt:set ${appname} email ${email}
       dokku letsencrypt:enable ${appname}
-      dokku config:set ${appname} --no-restart GOOGLE_CLIENT_ID=${google_client_id}
-      dokku config:set ${appname} --no-restart GOOGLE_CLIENT_SECRET=${google_client_secret}
+      dokku ps:restart ${appname}
 `;
 
   return (

--- a/frontend/src/tests/components/DokkuScripts/DokkuScriptGenerate.test.jsx
+++ b/frontend/src/tests/components/DokkuScripts/DokkuScriptGenerate.test.jsx
@@ -17,14 +17,17 @@ describe("DokkuScript tests", () => {
       dokku git:set happycows keep-git-dir true
       dokku config:set --no-restart happycows PRODUCTION=true
       dokku config:set --no-restart happycows SOURCE_REPO=https://github.com/ucsb-cs156/proj-happycows
+      dokku config:set happycows --no-restart GOOGLE_CLIENT_ID=get-value-from-google
+      dokku config:set happycows --no-restart GOOGLE_CLIENT_SECRET=get-value-from-google
       dokku postgres:create happycows-db
       dokku postgres:link happycows-db happycows
       dokku git:sync happycows https://github.com/ucsb-cs156/proj-happycows main
       dokku ps:rebuild happycows
       dokku letsencrypt:set happycows email phtcon@ucsb.edu
       dokku letsencrypt:enable happycows
-      dokku config:set happycows --no-restart GOOGLE_CLIENT_ID=get-value-from-google
-      dokku config:set happycows --no-restart GOOGLE_CLIENT_SECRET=get-value-from-google`;
+      dokku ps:restart happycows
+`;
+
     render(<DokkuScriptGenerate />);
     const dokkuscript = screen.getByTestId("dokkuscript");
     expect(dokkuscript).toHaveTextContent(expected, {


### PR DESCRIPTION
Closes #13 

In this PR, we update the dokku script for a faster, more efficient deployment.

Instead of building the application twice, we build it only once, and just restart it after adding the https certificate.
