### PR TITLE
Create Templated GitHub Apps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@uiw/react-json-view": "^2.0.0-alpha.34",
         "bootstrap": "^5.3.7",
+        "node-forge": "^1.4.0",
         "react": "^19.1.1",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.1.1",
@@ -8888,6 +8889,15 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@uiw/react-json-view": "^2.0.0-alpha.34",
     "bootstrap": "^5.3.7",
+    "node-forge": "^1.4.0",
     "react": "^19.1.1",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.1.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,8 @@ import HomePage from "main/pages/HomePage";
 import "bootstrap/dist/css/bootstrap.css";
 import "react-toastify/dist/ReactToastify.css";
 import FrontiersAppPage from "main/pages/FrontiersAppPage.jsx";
-import FrontiersAppReturn from "main/pages/FrontiersAppReturn.jsx";
+import FrontiersAppReturnDokku from "main/pages/FrontiersAppReturnDokku.jsx";
+import FrontiersAppReturnLocalhost from "main/pages/FrontiersAppReturnLocalhost.jsx";
 
 function App() {
   return (
@@ -12,8 +13,13 @@ function App() {
       <Route exact path="/frontiers" element={<FrontiersAppPage />} />
       <Route
         exact
-        path="/frontiers/complete"
-        element={<FrontiersAppReturn />}
+        path="/frontiers/complete/dokku"
+        element={<FrontiersAppReturnDokku />}
+      />
+      <Route
+        exact
+        path="/frontiers/complete/localhost"
+        element={<FrontiersAppReturnLocalhost />}
       />
     </Routes>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,11 +2,19 @@ import { Routes, Route } from "react-router";
 import HomePage from "main/pages/HomePage";
 import "bootstrap/dist/css/bootstrap.css";
 import "react-toastify/dist/ReactToastify.css";
+import FrontiersAppPage from "main/pages/FrontiersAppPage.jsx";
+import FrontiersAppReturn from "main/pages/FrontiersAppReturn.jsx";
 
 function App() {
   return (
     <Routes>
       <Route exact path="/" element={<HomePage />} />
+      <Route exact path="/frontiers" element={<FrontiersAppPage />} />
+      <Route
+        exact
+        path="/frontiers/complete"
+        element={<FrontiersAppReturn />}
+      />
     </Routes>
   );
 }

--- a/frontend/src/fixtures/GitHubAppManifestFixtures.js
+++ b/frontend/src/fixtures/GitHubAppManifestFixtures.js
@@ -15,7 +15,7 @@ export const GitHubAppManifestFixtures = {
       url: `https://test.dokku-00.cs.ucsb.edu/api/webhooks/github`,
     },
     default_events: ["organization"],
-    redirect_url: `${window.location.href}/complete`,
+    redirect_url: `${window.location.origin}${window.location.pathname}/complete`,
     callback_urls: [
       `https://test.dokku-00.cs.ucsb.edu/api/courses/link`,
       `https://test.dokku-00.cs.ucsb.edu/login/oauth2/code/github`,

--- a/frontend/src/fixtures/GitHubAppManifestFixtures.js
+++ b/frontend/src/fixtures/GitHubAppManifestFixtures.js
@@ -1,0 +1,30 @@
+export const GitHubAppManifestFixtures = {
+  TestApp: {
+    default_permissions: {
+      administration: "write",
+      contents: "write",
+      workflows: "write",
+      organization_administration: "write",
+      members: "write",
+    },
+    request_oauth_on_install: true,
+    public: true,
+    name: `test-dokku-00`,
+    url: "https://test.dokku-00.cs.ucsb.edu",
+    hook_attributes: {
+      url: `https://test.dokku-00.cs.ucsb.edu/api/webhooks/github`,
+    },
+    default_events: ["organization"],
+    redirect_url: `${window.location.href}/complete`,
+    callback_urls: [
+      `https://test.dokku-00.cs.ucsb.edu/api/courses/link`,
+      `https://test.dokku-00.cs.ucsb.edu/login/oauth2/code/github`,
+    ],
+  },
+  TestAppResponse: {
+    webhook_secret: "test-webhook-secret",
+    pem: "fake-private-key",
+    client_id: "test-client-id",
+    client_secret: "test-client-secret",
+  },
+};

--- a/frontend/src/fixtures/GitHubAppManifestFixtures.js
+++ b/frontend/src/fixtures/GitHubAppManifestFixtures.js
@@ -1,5 +1,5 @@
 export const GitHubAppManifestFixtures = {
-  TestApp: {
+  TestAppDokku: {
     default_permissions: {
       administration: "write",
       contents: "write",
@@ -15,14 +15,39 @@ export const GitHubAppManifestFixtures = {
       url: `https://test.dokku-00.cs.ucsb.edu/api/webhooks/github`,
     },
     default_events: ["organization"],
-    redirect_url: `${window.location.origin}${window.location.pathname}/complete`,
+    redirect_url: `${window.location.origin}${window.location.pathname}/complete/dokku`,
     callback_urls: [
       `https://test.dokku-00.cs.ucsb.edu/api/courses/link`,
       `https://test.dokku-00.cs.ucsb.edu/login/oauth2/code/github`,
     ],
   },
-  TestAppResponse: {
+  TestAppDokkuResponse: {
     webhook_secret: "test-webhook-secret",
+    pem: "fake-private-key",
+    client_id: "test-client-id",
+    client_secret: "test-client-secret",
+  },
+
+  TestAppLocalhost: {
+    default_permissions: {
+      administration: "write",
+      contents: "write",
+      workflows: "write",
+      organization_administration: "write",
+      members: "write",
+    },
+    request_oauth_on_install: true,
+    public: true,
+    name: `TestApp on localhost`,
+    url: "http://localhost:8080",
+    redirect_url: `${window.location.origin}${window.location.pathname}/complete/localhost`,
+    callback_urls: [
+      `http://localhost:8080/api/courses/link`,
+      `http://localhost:8080/login/oauth2/code/github`,
+    ],
+  },
+
+  TestAppLocalhostResponse: {
     pem: "fake-private-key",
     client_id: "test-client-id",
     client_secret: "test-client-secret",

--- a/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
+++ b/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
@@ -26,7 +26,7 @@ function FrontiersAppFormDokku() {
       url: `${serverUrl}/api/webhooks/github`,
     },
     default_events: ["organization"],
-    redirect_url: `${window.location.href}/complete`,
+    redirect_url: `${window.location.origin}${window.location.pathname}/complete`,
     callback_urls: [
       `${serverUrl}/api/courses/link`,
       `${serverUrl}/login/oauth2/code/github`,
@@ -44,7 +44,7 @@ function FrontiersAppFormDokku() {
         data-testid="frontiers-app-form"
         onSubmit={handleSubmit(onSubmit)}
         method="POST"
-        action={`https://github.com/settings/apps/new?manifest=${JSON.stringify(appManifest)}`}
+        action={`https://github.com/settings/apps/new?manifest=${encodeURIComponent(JSON.stringify(appManifest))}`}
       >
         <Form.Group>
           <Form.Label htmlFor="appName">App Name</Form.Label>

--- a/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
+++ b/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
@@ -26,7 +26,7 @@ function FrontiersAppFormDokku() {
       url: `${serverUrl}/api/webhooks/github`,
     },
     default_events: ["organization"],
-    redirect_url: `${window.location.origin}${window.location.pathname}/complete`,
+    redirect_url: `${window.location.origin}${window.location.pathname}/complete/dokku`,
     callback_urls: [
       `${serverUrl}/api/courses/link`,
       `${serverUrl}/login/oauth2/code/github`,

--- a/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
+++ b/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
@@ -1,0 +1,82 @@
+import { useForm } from "react-hook-form";
+import React, { useRef } from "react";
+import { BaseFrontiersManifest } from "main/utils/BaseFrontiersConfiguration.js";
+import { Form, Container, Button } from "react-bootstrap";
+
+function FrontiersAppFormDokku() {
+  const {
+    register,
+    formState: { errors },
+    watch,
+    handleSubmit,
+  } = useForm();
+
+  const formRef = useRef(null);
+
+  const servers = Array.from({ length: 17 }, (_, i) =>
+    i < 10 ? `0${i}` : `${i}`,
+  );
+  const serverUrl = `https://${watch("appName")}.dokku-${watch("dokkuServer")}.cs.ucsb.edu`;
+
+  const appManifest = {
+    ...BaseFrontiersManifest,
+    name: `${watch("appName")}-dokku-${watch("dokkuServer")}`,
+    url: serverUrl,
+    hook_attributes: {
+      url: `${serverUrl}/api/webhooks/github`,
+    },
+    default_events: ["organization"],
+    redirect_url: `${window.location.href}/complete`,
+    callback_urls: [
+      `${serverUrl}/api/courses/link`,
+      `${serverUrl}/login/oauth2/code/github`,
+    ],
+  };
+
+  const onSubmit = () => {
+    formRef.current.submit();
+  };
+
+  return (
+    <Container>
+      <Form
+        ref={formRef}
+        onSubmit={handleSubmit(onSubmit)}
+        method="POST"
+        action={`https://github.com/settings/apps/new?manifest=${JSON.stringify(appManifest)}`}
+      >
+        <Form.Group>
+          <Form.Label>App Name</Form.Label>
+          <Form.Control
+            type="text"
+            placeholder="Enter app name"
+            {...register("appName", { required: true })}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.appName && "App Name is required."}
+          </Form.Control.Feedback>
+          <Form.Label>Dokku Server</Form.Label>
+          <Form.Control
+            as="select"
+            id="dokkuServer"
+            {...register("dokkuServer", { required: true })}
+          >
+            {servers.map((number) => (
+              <option key={number} value={number}>
+                dokku-{number}
+              </option>
+            ))}
+          </Form.Control>
+          <Form.Control.Feedback type="invalid">
+            {errors.dokkuServer && "Dokku Server is required."}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group>
+          <Button type="submit">Create Frontiers App</Button>
+        </Form.Group>
+      </Form>
+    </Container>
+  );
+}
+
+export default FrontiersAppFormDokku;

--- a/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
+++ b/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
@@ -34,6 +34,7 @@ function FrontiersAppFormDokku() {
   };
 
   const onSubmit = () => {
+    sessionStorage.setItem("frontiers-dokku-appname", watch("appName"));
     formRef.current.submit();
   };
 

--- a/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
+++ b/frontend/src/main/components/FrontiersApp/FrontiersAppFormDokku.jsx
@@ -41,26 +41,31 @@ function FrontiersAppFormDokku() {
     <Container>
       <Form
         ref={formRef}
+        data-testid="frontiers-app-form"
         onSubmit={handleSubmit(onSubmit)}
         method="POST"
         action={`https://github.com/settings/apps/new?manifest=${JSON.stringify(appManifest)}`}
       >
         <Form.Group>
-          <Form.Label>App Name</Form.Label>
+          <Form.Label htmlFor="appName">App Name</Form.Label>
           <Form.Control
             type="text"
+            id="appName"
             placeholder="Enter app name"
+            isInvalid={!!errors.appName}
             {...register("appName", { required: true })}
           />
           <Form.Control.Feedback type="invalid">
             {errors.appName && "App Name is required."}
           </Form.Control.Feedback>
-          <Form.Label>Dokku Server</Form.Label>
+          <Form.Label htmlFor="dokkuServer">Dokku Server</Form.Label>
           <Form.Control
             as="select"
             id="dokkuServer"
+            isInvalid={!!errors.dokkuServer}
             {...register("dokkuServer", { required: true })}
           >
+            <option value="">Select a Dokku Server</option>
             {servers.map((number) => (
               <option key={number} value={number}>
                 dokku-{number}
@@ -71,7 +76,7 @@ function FrontiersAppFormDokku() {
             {errors.dokkuServer && "Dokku Server is required."}
           </Form.Control.Feedback>
         </Form.Group>
-        <Form.Group>
+        <Form.Group className="pt-3">
           <Button type="submit">Create Frontiers App</Button>
         </Form.Group>
       </Form>

--- a/frontend/src/main/components/FrontiersApp/FrontiersAppFormLocalhost.jsx
+++ b/frontend/src/main/components/FrontiersApp/FrontiersAppFormLocalhost.jsx
@@ -1,0 +1,62 @@
+import { useForm } from "react-hook-form";
+import React, { useRef } from "react";
+import { BaseFrontiersManifest } from "main/utils/BaseFrontiersConfiguration.js";
+import { Form, Container, Button } from "react-bootstrap";
+
+function FrontiersAppFormLocalhost() {
+  const {
+    register,
+    formState: { errors },
+    watch,
+    handleSubmit,
+  } = useForm();
+
+  const formRef = useRef(null);
+  const serverUrl = `http://localhost:8080`;
+
+  const appManifest = {
+    ...BaseFrontiersManifest,
+    name: `${watch("appName")} on localhost`,
+    url: serverUrl,
+    redirect_url: `${window.location.origin}${window.location.pathname}/complete/localhost`,
+    callback_urls: [
+      `${serverUrl}/api/courses/link`,
+      `${serverUrl}/login/oauth2/code/github`,
+    ],
+  };
+
+  const onSubmit = () => {
+    formRef.current.submit();
+  };
+
+  return (
+    <Container>
+      <Form
+        ref={formRef}
+        data-testid="frontiers-app-form-localhost"
+        onSubmit={handleSubmit(onSubmit)}
+        method="POST"
+        action={`https://github.com/settings/apps/new?manifest=${encodeURIComponent(JSON.stringify(appManifest))}`}
+      >
+        <Form.Group>
+          <Form.Label htmlFor="appName">App Name</Form.Label>
+          <Form.Control
+            type="text"
+            id="appName"
+            placeholder="Enter app name"
+            isInvalid={!!errors.appName}
+            {...register("appName", { required: true })}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.appName && "App Name is required."}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group className="pt-3">
+          <Button type="submit">Create Frontiers App</Button>
+        </Form.Group>
+      </Form>
+    </Container>
+  );
+}
+
+export default FrontiersAppFormLocalhost;

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -23,6 +23,9 @@ export default function AppNavbar() {
               <Nav.Link as={Link} to="/">
                 Home
               </Nav.Link>
+              <Nav.Link as={Link} to="/frontiers">
+                Frontiers
+              </Nav.Link>
             </Nav>
           </Navbar.Collapse>
         </Container>

--- a/frontend/src/main/pages/FrontiersAppPage.jsx
+++ b/frontend/src/main/pages/FrontiersAppPage.jsx
@@ -1,5 +1,10 @@
 import FrontiersAppFormDokku from "main/components/FrontiersApp/FrontiersAppFormDokku.jsx";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout.jsx";
 
 export default function FrontiersAppPage() {
-  return <FrontiersAppFormDokku />;
+  return (
+    <BasicLayout>
+      <FrontiersAppFormDokku />
+    </BasicLayout>
+  );
 }

--- a/frontend/src/main/pages/FrontiersAppPage.jsx
+++ b/frontend/src/main/pages/FrontiersAppPage.jsx
@@ -1,10 +1,44 @@
 import FrontiersAppFormDokku from "main/components/FrontiersApp/FrontiersAppFormDokku.jsx";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout.jsx";
+import { useForm } from "react-hook-form";
+import { Col, Row, Form } from "react-bootstrap";
+import FrontiersAppFormLocalhost from "main/components/FrontiersApp/FrontiersAppFormLocalhost.jsx";
 
 export default function FrontiersAppPage() {
+  const { watch, register } = useForm();
+
+  const localhostOrDokku = watch("dokkuOrLocalhost");
   return (
     <BasicLayout>
-      <FrontiersAppFormDokku />
+      <Row>
+        <Col xs={2}>
+          <Form.Label>Dokku or Localhost</Form.Label>
+          <Form.Check
+            inline
+            defaultChecked={true}
+            type="radio"
+            label="Dokku"
+            value="dokku"
+            id="dokku-radio"
+            {...register("dokkuOrLocalhost")}
+          />
+          <Form.Check
+            inline
+            type="radio"
+            label="Localhost"
+            value="localhost"
+            id="localhost-radio"
+            {...register("dokkuOrLocalhost")}
+          />
+        </Col>
+      </Row>
+      <Row>
+        {localhostOrDokku === "dokku" ? (
+          <FrontiersAppFormDokku />
+        ) : (
+          <FrontiersAppFormLocalhost />
+        )}
+      </Row>
     </BasicLayout>
   );
 }

--- a/frontend/src/main/pages/FrontiersAppPage.jsx
+++ b/frontend/src/main/pages/FrontiersAppPage.jsx
@@ -1,0 +1,5 @@
+import FrontiersAppFormDokku from "main/components/FrontiersApp/FrontiersAppFormDokku.jsx";
+
+export default function FrontiersAppPage() {
+  return <FrontiersAppFormDokku />;
+}

--- a/frontend/src/main/pages/FrontiersAppReturn.jsx
+++ b/frontend/src/main/pages/FrontiersAppReturn.jsx
@@ -55,14 +55,13 @@ export default function FrontiersAppReturn() {
           <>
             <p>Run the following commands on dokku:</p>
             <code>
-              dokku config:set --no-restart {"<appname>"} APP_PRIVATE_KEY="
-              {resultData.pkcs8}" <br />
-              dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_ID="
-              {resultData.client_id}" <br />
-              dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_SECRET="
-              {resultData.client_secret}" <br />
-              dokku config:set {"<appname>"} WEBHOOK_SECRET="
-              {resultData.webhook_secret}"
+              {/*prettier-ignore*/}
+              <pre>
+                dokku config:set --no-restart {"<appname>"} APP_PRIVATE_KEY="{resultData.pkcs8}" <br />
+                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_ID="{resultData.client_id}" <br />
+                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_SECRET="{resultData.client_secret}" <br />
+                dokku config:set {"<appname>"} WEBHOOK_SECRET="{resultData.webhook_secret}"
+              </pre>
             </code>
           </>
         )}

--- a/frontend/src/main/pages/FrontiersAppReturn.jsx
+++ b/frontend/src/main/pages/FrontiersAppReturn.jsx
@@ -7,8 +7,9 @@ import forge from "node-forge";
 export default function FrontiersAppReturn() {
   const [searchParams, _setSearchParams] = useSearchParams("code");
   const [resultData, setResultData] = useState(null);
+  const [resultError, setResultError] = useState(false);
   useEffect(() => {
-    if (searchParams.get("code") !== null) {
+    if (searchParams.get("code") !== "") {
       axios
         .post(
           `https://api.github.com/app-manifests/${searchParams.get("code")}/conversions`,
@@ -23,6 +24,10 @@ export default function FrontiersAppReturn() {
           response.data.pkcs8 = forge.pki.privateKeyInfoToPem(privateKeyInfo);
 
           setResultData(response.data);
+        })
+        .catch((error) => {
+          setResultError(true);
+          console.error("failed to create app on GitHub: " + error);
         });
     }
   }, [searchParams]);
@@ -30,7 +35,22 @@ export default function FrontiersAppReturn() {
   return (
     <BasicLayout>
       <div>
-        <p>Frontiers App Return Page</p>
+        <h2>Dokku Commands</h2>
+        {!searchParams.get("code") && (
+          <>
+            <p>
+              Something went wrong; Github did not provide an app creation code.
+            </p>
+          </>
+        )}
+        {resultError && (
+          <>
+            <p>
+              Something went wrong; The app code could not be exchanged for
+              credentials.
+            </p>
+          </>
+        )}
         {resultData && (
           <>
             <p>Run the following commands on dokku:</p>

--- a/frontend/src/main/pages/FrontiersAppReturn.jsx
+++ b/frontend/src/main/pages/FrontiersAppReturn.jsx
@@ -1,0 +1,52 @@
+import { useSearchParams } from "react-router";
+import axios from "axios";
+import { useState, useEffect } from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout.jsx";
+import forge from "node-forge";
+
+export default function FrontiersAppReturn() {
+  const [searchParams, _setSearchParams] = useSearchParams("code");
+  const [resultData, setResultData] = useState(null);
+  useEffect(() => {
+    if (searchParams.get("code") !== null) {
+      axios
+        .post(
+          `https://api.github.com/app-manifests/${searchParams.get("code")}/conversions`,
+        )
+        .then((response) => {
+          const pem = forge.pki.privateKeyFromPem(response.data.pem);
+
+          const rsaPrivateKey = forge.pki.privateKeyToAsn1(pem);
+
+          const privateKeyInfo = forge.pki.wrapRsaPrivateKey(rsaPrivateKey);
+
+          response.data.pkcs8 = forge.pki.privateKeyInfoToPem(privateKeyInfo);
+
+          setResultData(response.data);
+        });
+    }
+  }, [searchParams]);
+
+  return (
+    <BasicLayout>
+      <div>
+        <p>Frontiers App Return Page</p>
+        {resultData && (
+          <>
+            <p>Run the following commands on dokku:</p>
+            <code>
+              dokku config:set --no-restart {"<appname>"} APP_PRIVATE_KEY="
+              {resultData.pkcs8}" <br />
+              dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_ID="
+              {resultData.client_id}" <br />
+              dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_SECRET="
+              {resultData.client_secret}" <br />
+              dokku config:set {"<appname>"} WEBHOOK_SECRET="
+              {resultData.webhook_secret}"
+            </code>
+          </>
+        )}
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/FrontiersAppReturnDokku.jsx
+++ b/frontend/src/main/pages/FrontiersAppReturnDokku.jsx
@@ -32,6 +32,9 @@ export default function FrontiersAppReturnDokku() {
     }
   }, [searchParams]);
 
+  const appName =
+    sessionStorage.getItem("frontiers-dokku-appname") || "<appname>";
+
   return (
     <BasicLayout>
       <div>
@@ -57,10 +60,10 @@ export default function FrontiersAppReturnDokku() {
             <code>
               {/*prettier-ignore*/}
               <pre>
-                dokku config:set --no-restart {"<appname>"} APP_PRIVATE_KEY="{resultData.pkcs8}" <br />
-                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_ID="{resultData.client_id}" <br />
-                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_SECRET="{resultData.client_secret}" <br />
-                dokku config:set {"<appname>"} WEBHOOK_SECRET="{resultData.webhook_secret}"
+                dokku config:set --no-restart {appName} APP_PRIVATE_KEY="{resultData.pkcs8}" <br />
+                dokku config:set --no-restart {appName} GITHUB_CLIENT_ID="{resultData.client_id}" <br />
+                dokku config:set --no-restart {appName} GITHUB_CLIENT_SECRET="{resultData.client_secret}" <br />
+                dokku config:set {appName} WEBHOOK_SECRET="{resultData.webhook_secret}"
               </pre>
             </code>
           </>

--- a/frontend/src/main/pages/FrontiersAppReturnDokku.jsx
+++ b/frontend/src/main/pages/FrontiersAppReturnDokku.jsx
@@ -1,0 +1,71 @@
+import { useSearchParams } from "react-router";
+import axios from "axios";
+import { useState, useEffect } from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout.jsx";
+import forge from "node-forge";
+
+export default function FrontiersAppReturnDokku() {
+  const [searchParams, _setSearchParams] = useSearchParams("code");
+  const [resultData, setResultData] = useState(null);
+  const [resultError, setResultError] = useState(false);
+  useEffect(() => {
+    if (searchParams.get("code") !== "") {
+      axios
+        .post(
+          `https://api.github.com/app-manifests/${searchParams.get("code")}/conversions`,
+        )
+        .then((response) => {
+          const pem = forge.pki.privateKeyFromPem(response.data.pem);
+
+          const rsaPrivateKey = forge.pki.privateKeyToAsn1(pem);
+
+          const privateKeyInfo = forge.pki.wrapRsaPrivateKey(rsaPrivateKey);
+
+          response.data.pkcs8 = forge.pki.privateKeyInfoToPem(privateKeyInfo);
+
+          setResultData(response.data);
+        })
+        .catch((error) => {
+          setResultError(true);
+          console.error("failed to create app on GitHub: " + error);
+        });
+    }
+  }, [searchParams]);
+
+  return (
+    <BasicLayout>
+      <div>
+        <h2>Dokku Commands</h2>
+        {!searchParams.get("code") && (
+          <>
+            <p>
+              Something went wrong; Github did not provide an app creation code.
+            </p>
+          </>
+        )}
+        {resultError && (
+          <>
+            <p>
+              Something went wrong; The app code could not be exchanged for
+              credentials.
+            </p>
+          </>
+        )}
+        {resultData && (
+          <>
+            <p>Run the following commands on dokku:</p>
+            <code>
+              {/*prettier-ignore*/}
+              <pre>
+                dokku config:set --no-restart {"<appname>"} APP_PRIVATE_KEY="{resultData.pkcs8}" <br />
+                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_ID="{resultData.client_id}" <br />
+                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_SECRET="{resultData.client_secret}" <br />
+                dokku config:set {"<appname>"} WEBHOOK_SECRET="{resultData.webhook_secret}"
+              </pre>
+            </code>
+          </>
+        )}
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/FrontiersAppReturnLocalhost.jsx
+++ b/frontend/src/main/pages/FrontiersAppReturnLocalhost.jsx
@@ -3,8 +3,10 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout.jsx";
 import forge from "node-forge";
+import { Button, Row, Col } from "react-bootstrap";
+import { exportSecretsYaml } from "main/utils/SecretsYamlUtil.js";
 
-export default function FrontiersAppReturn() {
+export default function FrontiersAppReturnLocalhost() {
   const [searchParams, _setSearchParams] = useSearchParams("code");
   const [resultData, setResultData] = useState(null);
   const [resultError, setResultError] = useState(false);
@@ -32,10 +34,24 @@ export default function FrontiersAppReturn() {
     }
   }, [searchParams]);
 
+  const downloadableCallback = () => {
+    const blob = new Blob([exportSecretsYaml(resultData.pkcs8)], {
+      type: "text/plain",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "secrets.yaml";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <BasicLayout>
       <div>
-        <h2>Dokku Commands</h2>
+        <h2>Localhost Configuration</h2>
         {!searchParams.get("code") && (
           <>
             <p>
@@ -53,16 +69,24 @@ export default function FrontiersAppReturn() {
         )}
         {resultData && (
           <>
-            <p>Run the following commands on dokku:</p>
-            <code>
-              {/*prettier-ignore*/}
-              <pre>
-                dokku config:set --no-restart {"<appname>"} APP_PRIVATE_KEY="{resultData.pkcs8}" <br />
-                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_ID="{resultData.client_id}" <br />
-                dokku config:set --no-restart {"<appname>"} GITHUB_CLIENT_SECRET="{resultData.client_secret}" <br />
-                dokku config:set {"<appname>"} WEBHOOK_SECRET="{resultData.webhook_secret}"
-              </pre>
-            </code>
+            <Row>
+              <p>Add the following lines to your .env:</p>
+              <code>
+                {/*prettier-ignore*/}
+                <pre>
+                GITHUB_CLIENT_ID="{resultData.client_id}" <br />
+                GITHUB_CLIENT_SECRET="{resultData.client_secret}" <br />
+                </pre>
+              </code>
+            </Row>
+            <Row className="pb-2">
+              <Col>
+                <p>Download your private key:</p>
+                <Button onClick={downloadableCallback}>
+                  Download Private Key
+                </Button>
+              </Col>
+            </Row>
           </>
         )}
       </div>

--- a/frontend/src/main/utils/BaseFrontiersConfiguration.js
+++ b/frontend/src/main/utils/BaseFrontiersConfiguration.js
@@ -1,0 +1,11 @@
+export const BaseFrontiersManifest = {
+  default_permissions: {
+    administration: "write",
+    contents: "write",
+    workflows: "write",
+    organization_administration: "write",
+    members: "write",
+  },
+  request_oauth_on_install: true,
+  public: true,
+};

--- a/frontend/src/main/utils/SecretsYamlUtil.js
+++ b/frontend/src/main/utils/SecretsYamlUtil.js
@@ -1,0 +1,11 @@
+const exportSecretsYaml = (pkcs8) => {
+  const yaml = `
+app:
+  private:
+    key: "${pkcs8}"
+`;
+
+  return yaml;
+};
+
+export { exportSecretsYaml };

--- a/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
+++ b/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
@@ -23,7 +23,7 @@ describe("FrontiersAppFormDokku component tests", () => {
     expect(formElement).toHaveAttribute("method", "POST");
     expect(formElement).toHaveAttribute(
       "action",
-      `https://github.com/settings/apps/new?manifest=${encodeURIComponent(JSON.stringify(GitHubAppManifestFixtures.TestApp))}`,
+      `https://github.com/settings/apps/new?manifest=${encodeURIComponent(JSON.stringify(GitHubAppManifestFixtures.TestAppDokku))}`,
     );
     expect(appName).not.toHaveClass("is-invalid");
     expect(dokkuServer).not.toHaveClass("is-invalid");

--- a/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
+++ b/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
@@ -1,0 +1,46 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import FrontiersAppFormDokku from "main/components/FrontiersApp/FrontiersAppFormDokku.jsx";
+import { GitHubAppManifestFixtures } from "fixtures/GitHubAppManifestFixtures.js";
+
+describe("FrontiersAppFormDokku component tests", () => {
+  test("submit test", async () => {
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, "submit")
+      .mockImplementation(() => {});
+
+    render(<FrontiersAppFormDokku />);
+
+    const appName = screen.getByLabelText("App Name");
+    fireEvent.change(appName, { target: { value: "test" } });
+    const dokkuServer = screen.getByLabelText("Dokku Server");
+    fireEvent.change(dokkuServer, { target: { value: "00" } });
+
+    const submitButton = screen.getByText("Create Frontiers App");
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(submitSpy).toHaveBeenCalled());
+    const formElement = screen.getByTestId("frontiers-app-form");
+    expect(formElement).toHaveAttribute("method", "POST");
+    expect(formElement).toHaveAttribute(
+      "action",
+      `https://github.com/settings/apps/new?manifest=${JSON.stringify(GitHubAppManifestFixtures.TestApp)}`,
+    );
+    expect(appName).not.toHaveClass("is-invalid");
+    expect(dokkuServer).not.toHaveClass("is-invalid");
+  });
+
+  test("Various existence assertions", async () => {
+    render(<FrontiersAppFormDokku />);
+
+    for (let i = 0; i < 10; i++) {
+      expect(screen.getByText(`dokku-0${i}`)).toBeInTheDocument();
+    }
+    for (let i = 10; i < 17; i++) {
+      expect(screen.getByText(`dokku-${i}`)).toBeInTheDocument();
+    }
+
+    fireEvent.click(screen.getByText("Create Frontiers App"));
+    await screen.findByText("App Name is required.");
+    expect(screen.getByText("Dokku Server is required.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
+++ b/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
@@ -23,7 +23,7 @@ describe("FrontiersAppFormDokku component tests", () => {
     expect(formElement).toHaveAttribute("method", "POST");
     expect(formElement).toHaveAttribute(
       "action",
-      `https://github.com/settings/apps/new?manifest=${JSON.stringify(GitHubAppManifestFixtures.TestApp)}`,
+      `https://github.com/settings/apps/new?manifest=${encodeURIComponent(JSON.stringify(GitHubAppManifestFixtures.TestApp))}`,
     );
     expect(appName).not.toHaveClass("is-invalid");
     expect(dokkuServer).not.toHaveClass("is-invalid");

--- a/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
+++ b/frontend/src/tests/components/FrontiersApp/FrontiersAppFormDokku.test.jsx
@@ -27,6 +27,8 @@ describe("FrontiersAppFormDokku component tests", () => {
     );
     expect(appName).not.toHaveClass("is-invalid");
     expect(dokkuServer).not.toHaveClass("is-invalid");
+    expect(sessionStorage.getItem("frontiers-dokku-appname")).toBe("test");
+    sessionStorage.clear();
   });
 
   test("Various existence assertions", async () => {

--- a/frontend/src/tests/components/FrontiersApp/FrontiersAppFormLocalhost.test.jsx
+++ b/frontend/src/tests/components/FrontiersApp/FrontiersAppFormLocalhost.test.jsx
@@ -1,0 +1,37 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import { GitHubAppManifestFixtures } from "fixtures/GitHubAppManifestFixtures.js";
+import FrontiersAppFormLocalhost from "main/components/FrontiersApp/FrontiersAppFormLocalhost.jsx";
+
+describe("FrontiersAppFormLocalhost component tests", () => {
+  test("submit test", async () => {
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, "submit")
+      .mockImplementation(() => {});
+
+    render(<FrontiersAppFormLocalhost />);
+
+    const appName = screen.getByLabelText("App Name");
+    fireEvent.change(appName, { target: { value: "TestApp" } });
+
+    const submitButton = screen.getByText("Create Frontiers App");
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(submitSpy).toHaveBeenCalled());
+    const formElement = screen.getByTestId("frontiers-app-form-localhost");
+    expect(formElement).toHaveAttribute("method", "POST");
+    expect(formElement).toHaveAttribute(
+      "action",
+      `https://github.com/settings/apps/new?manifest=${encodeURIComponent(JSON.stringify(GitHubAppManifestFixtures.TestAppLocalhost))}`,
+    );
+    expect(appName).not.toHaveClass("is-invalid");
+  });
+
+  test("Various existence assertions", async () => {
+    render(<FrontiersAppFormLocalhost />);
+
+    fireEvent.click(screen.getByText("Create Frontiers App"));
+    expect(
+      await screen.findByText("App Name is required."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/FrontiersAppPage.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppPage.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import FrontiersAppPage from "main/pages/FrontiersAppPage.jsx";
+import { MemoryRouter } from "react-router";
+
+describe("FrontiersAppPage Page Tests", () => {
+  test("page renders", () => {
+    render(
+      <MemoryRouter>
+        <FrontiersAppPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Create Frontiers App")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/FrontiersAppPage.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppPage.test.jsx
@@ -1,14 +1,19 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import FrontiersAppPage from "main/pages/FrontiersAppPage.jsx";
 import { MemoryRouter } from "react-router";
 
 describe("FrontiersAppPage Page Tests", () => {
-  test("page renders", () => {
+  test("page renders", async () => {
     render(
       <MemoryRouter>
         <FrontiersAppPage />
       </MemoryRouter>,
     );
     expect(screen.getByText("Create Frontiers App")).toBeInTheDocument();
+    expect(screen.getByTestId("frontiers-app-form")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Localhost"));
+    expect(
+      await screen.findByTestId("frontiers-app-form-localhost"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/FrontiersAppReturn.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppReturn.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import FrontiersAppReturn from "main/pages/FrontiersAppReturn.jsx";
+import FrontiersAppReturnDokku from "src/main/pages/FrontiersAppReturnDokku.jsx";
 import {
   createMemoryRouter,
   MemoryRouter,
@@ -11,7 +11,7 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import { GitHubAppManifestFixtures } from "fixtures/GitHubAppManifestFixtures.js";
 import forge from "node-forge";
 
-describe("FrontiersAppReturn Page Tests", () => {
+describe("FrontiersAppReturnDokku Page Tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
   beforeEach(() => {
     axiosMock.reset();
@@ -36,10 +36,10 @@ describe("FrontiersAppReturn Page Tests", () => {
   test("Happy Path", async () => {
     axiosMock
       .onPost("https://api.github.com/app-manifests/code/conversions")
-      .reply(200, GitHubAppManifestFixtures.TestAppResponse);
+      .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
     render(
       <MemoryRouter initialEntries={["/frontiers/complete?code=code"]}>
-        <FrontiersAppReturn />
+        <FrontiersAppReturnDokku />
       </MemoryRouter>,
     );
 
@@ -78,11 +78,11 @@ describe("FrontiersAppReturn Page Tests", () => {
   test("no code", async () => {
     axiosMock
       .onPost("https://api.github.com/app-manifests/code/conversions")
-      .reply(200, GitHubAppManifestFixtures.TestAppResponse);
+      .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
 
     render(
       <MemoryRouter initialEntries={["/frontiers/complete"]}>
-        <FrontiersAppReturn />
+        <FrontiersAppReturnDokku />
       </MemoryRouter>,
     );
 
@@ -110,7 +110,7 @@ describe("FrontiersAppReturn Page Tests", () => {
 
     render(
       <MemoryRouter initialEntries={["/frontiers/complete?code=bad"]}>
-        <FrontiersAppReturn />
+        <FrontiersAppReturnDokku />
       </MemoryRouter>,
     );
     await screen.findByText(
@@ -137,7 +137,7 @@ describe("FrontiersAppReturn Page Tests", () => {
       const change = () => setSearchParams({ code: "bad" });
       return (
         <>
-          <FrontiersAppReturn />
+          <FrontiersAppReturnDokku />
           <button onClick={change}>Change Code</button>
         </>
       );
@@ -156,7 +156,7 @@ describe("FrontiersAppReturn Page Tests", () => {
 
     axiosMock
       .onPost("https://api.github.com/app-manifests/good/conversions")
-      .reply(200, GitHubAppManifestFixtures.TestAppResponse);
+      .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
     axiosMock
       .onPost("https://api.github.com/app-manifests/bad/conversions")
       .reply(403);

--- a/frontend/src/tests/pages/FrontiersAppReturn.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppReturn.test.jsx
@@ -1,0 +1,174 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import FrontiersAppReturn from "main/pages/FrontiersAppReturn.jsx";
+import {
+  createMemoryRouter,
+  MemoryRouter,
+  RouterProvider,
+  useSearchParams,
+} from "react-router";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { GitHubAppManifestFixtures } from "fixtures/GitHubAppManifestFixtures.js";
+import forge from "node-forge";
+
+describe("FrontiersAppReturn Page Tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    vi.spyOn(forge.pki, "privateKeyFromPem").mockImplementation(
+      (value) => value,
+    );
+    vi.spyOn(forge.pki, "privateKeyToAsn1").mockImplementation(
+      (value) => value,
+    );
+    vi.spyOn(forge.pki, "wrapRsaPrivateKey").mockImplementation(
+      (value) => value,
+    );
+    vi.spyOn(forge.pki, "privateKeyInfoToPem").mockImplementation(
+      (value) => value,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  test("Happy Path", async () => {
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/code/conversions")
+      .reply(200, GitHubAppManifestFixtures.TestAppResponse);
+    render(
+      <MemoryRouter initialEntries={["/frontiers/complete?code=code"]}>
+        <FrontiersAppReturn />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/APP_PRIVATE_KEY="fake-private-key"/);
+    expect(
+      screen.getByText(/GITHUB_CLIENT_ID="test-client-id"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/WEBHOOK_SECRET="test-webhook-secret"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/GITHUB_CLIENT_SECRET="test-client-secret"/),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByText(/dokku config:set --no-restart <appname>/)
+        .textContent.match(/dokku config:set --no-restart <appname>/g).length,
+    ).toBe(3);
+    expect(screen.getByText(/dokku config:set <appname>/)).toBeInTheDocument();
+    expect(forge.pki.privateKeyFromPem).toHaveBeenCalledWith(
+      "fake-private-key",
+    );
+    expect(forge.pki.privateKeyToAsn1).toHaveBeenCalledWith("fake-private-key");
+    expect(forge.pki.wrapRsaPrivateKey).toHaveBeenCalledWith(
+      "fake-private-key",
+    );
+    expect(forge.pki.privateKeyInfoToPem).toHaveBeenCalledWith(
+      "fake-private-key",
+    );
+
+    expect(axiosMock.history.post[0].url).toBe(
+      "https://api.github.com/app-manifests/code/conversions",
+    );
+  });
+
+  test("no code", async () => {
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/code/conversions")
+      .reply(200, GitHubAppManifestFixtures.TestAppResponse);
+
+    render(
+      <MemoryRouter initialEntries={["/frontiers/complete"]}>
+        <FrontiersAppReturn />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/Github did not provide an app creation code/);
+    expect(
+      screen.queryByText(/The app code could not be exchanged for credentials/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Run the following commands on dokku/),
+    ).not.toBeInTheDocument();
+    expect(axiosMock.history.post.length).toBe(0);
+    expect(forge.pki.privateKeyFromPem).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyToAsn1).not.toHaveBeenCalled();
+    expect(forge.pki.wrapRsaPrivateKey).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyInfoToPem).not.toHaveBeenCalled();
+  });
+
+  test("bad github response", async () => {
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/bad/conversions")
+      .reply(400, {
+        message: "Invalid app manifest code",
+      });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <MemoryRouter initialEntries={["/frontiers/complete?code=bad"]}>
+        <FrontiersAppReturn />
+      </MemoryRouter>,
+    );
+    await screen.findByText(
+      /The app code could not be exchanged for credentials/,
+    );
+    expect(
+      screen.queryByText(/Github did not provide an app creation code/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Run the following commands on dokku/),
+    ).not.toBeInTheDocument();
+    expect(forge.pki.privateKeyFromPem).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyToAsn1).not.toHaveBeenCalled();
+    expect(forge.pki.wrapRsaPrivateKey).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyInfoToPem).not.toHaveBeenCalled();
+    expect(console.error.mock.calls[0][0]).toContain(
+      "failed to create app on GitHub:",
+    );
+  });
+
+  test("hack to test useEffect dependency", async () => {
+    const Wrapper = () => {
+      const [_searchParams, setSearchParams] = useSearchParams();
+      const change = () => setSearchParams({ code: "bad" });
+      return (
+        <>
+          <FrontiersAppReturn />
+          <button onClick={change}>Change Code</button>
+        </>
+      );
+    };
+    const ProgrammaticMemoryRouter = createMemoryRouter(
+      [
+        {
+          path: "/frontiers/complete",
+          element: <Wrapper />,
+        },
+      ],
+      {
+        initialEntries: ["/frontiers/complete?code=good"],
+      },
+    );
+
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/good/conversions")
+      .reply(200, GitHubAppManifestFixtures.TestAppResponse);
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/bad/conversions")
+      .reply(403);
+
+    render(<RouterProvider router={ProgrammaticMemoryRouter} />);
+
+    await screen.findByText(/Run the following commands on dokku/);
+    fireEvent.click(screen.getByText(/Change Code/));
+    expect(
+      await screen.findByText(
+        /The app code could not be exchanged for credentials/,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/FrontiersAppReturnDokku.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppReturnDokku.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import FrontiersAppReturnDokku from "src/main/pages/FrontiersAppReturnDokku.jsx";
+import FrontiersAppReturnDokku from "main/pages/FrontiersAppReturnDokku.jsx";
 import {
   createMemoryRouter,
   MemoryRouter,
@@ -38,7 +38,7 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
       .onPost("https://api.github.com/app-manifests/code/conversions")
       .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
     render(
-      <MemoryRouter initialEntries={["/frontiers/complete?code=code"]}>
+      <MemoryRouter initialEntries={["/frontiers/complete/dokku?code=code"]}>
         <FrontiersAppReturnDokku />
       </MemoryRouter>,
     );
@@ -81,7 +81,7 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
       .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
 
     render(
-      <MemoryRouter initialEntries={["/frontiers/complete"]}>
+      <MemoryRouter initialEntries={["/frontiers/complete/dokku"]}>
         <FrontiersAppReturnDokku />
       </MemoryRouter>,
     );
@@ -109,7 +109,7 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     render(
-      <MemoryRouter initialEntries={["/frontiers/complete?code=bad"]}>
+      <MemoryRouter initialEntries={["/frontiers/complete/dokku?code=bad"]}>
         <FrontiersAppReturnDokku />
       </MemoryRouter>,
     );
@@ -145,12 +145,12 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
     const ProgrammaticMemoryRouter = createMemoryRouter(
       [
         {
-          path: "/frontiers/complete",
+          path: "/frontiers/complete/dokku",
           element: <Wrapper />,
         },
       ],
       {
-        initialEntries: ["/frontiers/complete?code=good"],
+        initialEntries: ["/frontiers/complete/dokku?code=good"],
       },
     );
 

--- a/frontend/src/tests/pages/FrontiersAppReturnDokku.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppReturnDokku.test.jsx
@@ -37,6 +37,8 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
     axiosMock
       .onPost("https://api.github.com/app-manifests/code/conversions")
       .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
+    sessionStorage.setItem("frontiers-dokku-appname", "test-app");
+
     render(
       <MemoryRouter initialEntries={["/frontiers/complete/dokku?code=code"]}>
         <FrontiersAppReturnDokku />
@@ -55,10 +57,10 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
     ).toBeInTheDocument();
     expect(
       screen
-        .getByText(/dokku config:set --no-restart <appname>/)
-        .textContent.match(/dokku config:set --no-restart <appname>/g).length,
+        .getByText(/dokku config:set --no-restart test-app/)
+        .textContent.match(/dokku config:set --no-restart test-app/g).length,
     ).toBe(3);
-    expect(screen.getByText(/dokku config:set <appname>/)).toBeInTheDocument();
+    expect(screen.getByText(/dokku config:set test-app/)).toBeInTheDocument();
     expect(forge.pki.privateKeyFromPem).toHaveBeenCalledWith(
       "fake-private-key",
     );
@@ -73,6 +75,7 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
     expect(axiosMock.history.post[0].url).toBe(
       "https://api.github.com/app-manifests/code/conversions",
     );
+    sessionStorage.clear();
   });
 
   test("no code", async () => {
@@ -164,6 +167,9 @@ describe("FrontiersAppReturnDokku Page Tests", () => {
     render(<RouterProvider router={ProgrammaticMemoryRouter} />);
 
     await screen.findByText(/Run the following commands on dokku/);
+    expect(
+      screen.getByText(/dokku config:set --no-restart <appname>/),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByText(/Change Code/));
     expect(
       await screen.findByText(

--- a/frontend/src/tests/pages/FrontiersAppReturnLocalhost.test.jsx
+++ b/frontend/src/tests/pages/FrontiersAppReturnLocalhost.test.jsx
@@ -1,0 +1,197 @@
+import AxiosMockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import forge from "node-forge";
+import { GitHubAppManifestFixtures } from "fixtures/GitHubAppManifestFixtures.js";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  createMemoryRouter,
+  MemoryRouter,
+  RouterProvider,
+  useSearchParams,
+} from "react-router";
+import FrontiersAppReturnLocalhost from "main/pages/FrontiersAppReturnLocalhost.jsx";
+import * as secretsYaml from "main/utils/SecretsYamlUtil.js";
+
+describe("FrontiersAppReturnLocalhost page tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    vi.spyOn(forge.pki, "privateKeyFromPem").mockImplementation(
+      (value) => value,
+    );
+    vi.spyOn(forge.pki, "privateKeyToAsn1").mockImplementation(
+      (value) => value,
+    );
+    vi.spyOn(forge.pki, "wrapRsaPrivateKey").mockImplementation(
+      (value) => value,
+    );
+    vi.spyOn(forge.pki, "privateKeyInfoToPem").mockImplementation(
+      (value) => value,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  test("Happy Path", async () => {
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/code/conversions")
+      .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
+
+    vi.spyOn(secretsYaml, "exportSecretsYaml").mockImplementation(
+      (start) => start,
+    );
+
+    render(
+      <MemoryRouter
+        initialEntries={["/frontiers/complete/localhost?code=code"]}
+      >
+        <FrontiersAppReturnLocalhost />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(/GITHUB_CLIENT_ID="test-client-id"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/GITHUB_CLIENT_SECRET="test-client-secret"/),
+    ).toBeInTheDocument();
+    expect(forge.pki.privateKeyFromPem).toHaveBeenCalledWith(
+      "fake-private-key",
+    );
+    expect(forge.pki.privateKeyToAsn1).toHaveBeenCalledWith("fake-private-key");
+    expect(forge.pki.wrapRsaPrivateKey).toHaveBeenCalledWith(
+      "fake-private-key",
+    );
+    expect(forge.pki.privateKeyInfoToPem).toHaveBeenCalledWith(
+      "fake-private-key",
+    );
+
+    expect(axiosMock.history.post[0].url).toBe(
+      "https://api.github.com/app-manifests/code/conversions",
+    );
+
+    const linkElem = {
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    URL.createObjectURL = vi.fn(() => "passthrough");
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(document, "createElement").mockImplementation(() => linkElem);
+    vi.spyOn(document.body, "appendChild").mockImplementation(() => {});
+    const blobMock = vi.fn();
+    vi.stubGlobal("Blob", blobMock);
+
+    fireEvent.click(screen.getByText("Download Private Key"));
+
+    await waitFor(() => expect(linkElem.remove).toHaveBeenCalled());
+    expect(blobMock).toHaveBeenCalledWith(["fake-private-key"], {
+      type: "text/plain",
+    });
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("passthrough");
+    expect(linkElem.click).toHaveBeenCalled();
+    expect(document.createElement).toHaveBeenCalledWith("a");
+    expect(document.body.appendChild).toHaveBeenCalledWith(linkElem);
+    expect(linkElem.href).toBe("passthrough");
+    expect(linkElem.download).toBe("secrets.yaml");
+  });
+
+  test("no code", async () => {
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/code/conversions")
+      .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
+
+    render(
+      <MemoryRouter initialEntries={["/frontiers/complete/localhost"]}>
+        <FrontiersAppReturnLocalhost />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/Github did not provide an app creation code/);
+    expect(
+      screen.queryByText(/The app code could not be exchanged for credentials/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Add the following lines to your \.env:/),
+    ).not.toBeInTheDocument();
+    expect(axiosMock.history.post.length).toBe(0);
+    expect(forge.pki.privateKeyFromPem).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyToAsn1).not.toHaveBeenCalled();
+    expect(forge.pki.wrapRsaPrivateKey).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyInfoToPem).not.toHaveBeenCalled();
+  });
+
+  test("bad github response", async () => {
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/bad/conversions")
+      .reply(400, {
+        message: "Invalid app manifest code",
+      });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <MemoryRouter initialEntries={["/frontiers/complete/localhost?code=bad"]}>
+        <FrontiersAppReturnLocalhost />
+      </MemoryRouter>,
+    );
+    await screen.findByText(
+      /The app code could not be exchanged for credentials/,
+    );
+    expect(
+      screen.queryByText(/Github did not provide an app creation code/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Add the following lines to your \\.env:/),
+    ).not.toBeInTheDocument();
+    expect(forge.pki.privateKeyFromPem).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyToAsn1).not.toHaveBeenCalled();
+    expect(forge.pki.wrapRsaPrivateKey).not.toHaveBeenCalled();
+    expect(forge.pki.privateKeyInfoToPem).not.toHaveBeenCalled();
+    expect(console.error.mock.calls[0][0]).toContain(
+      "failed to create app on GitHub:",
+    );
+  });
+
+  test("hack to test useEffect dependency", async () => {
+    const Wrapper = () => {
+      const [_searchParams, setSearchParams] = useSearchParams();
+      const change = () => setSearchParams({ code: "bad" });
+      return (
+        <>
+          <FrontiersAppReturnLocalhost />
+          <button onClick={change}>Change Code</button>
+        </>
+      );
+    };
+    const ProgrammaticMemoryRouter = createMemoryRouter(
+      [
+        {
+          path: "/frontiers/complete/localhost",
+          element: <Wrapper />,
+        },
+      ],
+      {
+        initialEntries: ["/frontiers/complete/localhost?code=good"],
+      },
+    );
+
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/good/conversions")
+      .reply(200, GitHubAppManifestFixtures.TestAppDokkuResponse);
+    axiosMock
+      .onPost("https://api.github.com/app-manifests/bad/conversions")
+      .reply(403);
+
+    render(<RouterProvider router={ProgrammaticMemoryRouter} />);
+
+    await screen.findByText(/Add the following lines to your \.env:/);
+    fireEvent.click(screen.getByText(/Change Code/));
+    expect(
+      await screen.findByText(
+        /The app code could not be exchanged for credentials/,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/utils/SecretsYamlUtil.test.js
+++ b/frontend/src/tests/utils/SecretsYamlUtil.test.js
@@ -1,0 +1,9 @@
+import { exportSecretsYaml } from "main/utils/SecretsYamlUtil.js";
+
+test("simple secretsYamlUtil test", () => {
+  expect(exportSecretsYaml("key")).toBe(`
+app:
+  private:
+    key: "key"
+`);
+});


### PR DESCRIPTION
In this PR, I add the ability to create a GitHub app from a template.
These apps start with the required Github permissions for Frontiers, and have a reference to the configured Dokku application or are setup with a webhook for localhost.

To Test:
1. Run the branch locally (`npm ci && npm start`)
2. Click "Frontiers" in the navbar
3. fill in an app name and pick a dokku server.
4. Note the credentials.

To fully test, create another frontiers deployment with the same app name on the selected dokku server, and run the commands provided. Notably, do not navigate away -- the credentials will disappear on page change.

Then, try a similar set of actions for localhost.

Adds `node-forge` to convert the key from `PKCS1` to `PKCS8`, a Frontiers/Java compatible format.

Created example: https://frontiers.dokku-12.cs.ucsb.edu/